### PR TITLE
feat(diagram): Implement DestructionDrawable, limit lifeline height

### DIFF
--- a/src/diagram/drawables/destruction-drawable.ts
+++ b/src/diagram/drawables/destruction-drawable.ts
@@ -1,0 +1,33 @@
+import { Drawable } from './drawable'
+import { Point } from '../../util/geometry/point'
+import { RenderAttributes, Renderer } from '../../renderer/renderer'
+import { Size } from '../../util/geometry/size'
+
+const DESTRUCTION_PATH = 'M-13,-13 L13,13 M-13,13 L13,-13'
+
+/**
+ * A cross-shaped object destruction pictogram.
+ */
+export class DestructionDrawable implements Drawable {
+  private position: Point = Point.ORIGIN
+
+  /**
+   * Sets the position of this pictogram.
+   * The position specifies the center point of the cross.
+   *
+   * @param position The position.
+   */
+  setPosition (position: Point): void {
+    this.position = position
+  }
+
+  measure (_attr: RenderAttributes): Size {
+    return new Size(26, 26)
+  }
+
+  draw (renderer: Renderer): void {
+    renderer.renderPath(DESTRUCTION_PATH, this.position, {
+      lineWidth: 3
+    })
+  }
+}

--- a/src/diagram/drawables/lifeline-drawable.ts
+++ b/src/diagram/drawables/lifeline-drawable.ts
@@ -4,6 +4,7 @@ import { Point } from '../../util/geometry/point'
 import { RenderAttributes, Renderer } from '../../renderer/renderer'
 import { Size } from '../../util/geometry/size'
 import { LINE_WIDTH_LIFELINES } from '../config'
+import { DestructionDrawable } from './destruction-drawable'
 
 /**
  * A drawable for a complete entity lifeline, including a configurable head and the line itself.
@@ -13,6 +14,7 @@ export class LifelineDrawable implements Drawable {
 
   private position: Point = Point.ORIGIN
   private endHeight: number = 0
+  private endDrawable: DestructionDrawable | undefined
 
   constructor (head: HeadDrawable) {
     this.head = head
@@ -31,13 +33,15 @@ export class LifelineDrawable implements Drawable {
   }
 
   /**
-   * Set the y coordinate at which the lifeline stops. This is an absolute coordinate,
-   * independent of the lifeline's anchor position.
+   * Set the y coordinate at which the lifeline stops, and the mode of stopping.
+   * The coordinate is absolute, independent of the lifeline's anchor position.
    *
    * @param endHeight The absolute height at which the lifeline stops.
+   * @param destroy Whether the lifeline ends with a destruction, or simply ends.
    */
-  setEndHeight (endHeight: number): void {
+  setEnd (endHeight: number, destroy: boolean): void {
     this.endHeight = endHeight
+    this.endDrawable = destroy ? new DestructionDrawable() : undefined
   }
 
   /**
@@ -72,5 +76,10 @@ export class LifelineDrawable implements Drawable {
       lineWidth: LINE_WIDTH_LIFELINES,
       dashed: true
     })
+
+    if (this.endDrawable != null) {
+      this.endDrawable.setPosition(lineEnd)
+      this.endDrawable.draw(renderer)
+    }
   }
 }

--- a/src/diagram/parts/entity-diagram-part.ts
+++ b/src/diagram/parts/entity-diagram-part.ts
@@ -30,6 +30,7 @@ export class EntityDiagramPart implements DiagramPart {
   private readonly drawable: LifelineDrawable
   private topCenter: Point = Point.ORIGIN
   private lifelineEndY: number = 0
+  private destroy: boolean = false
 
   constructor (entity: Entity) {
     this.entity = entity
@@ -59,18 +60,20 @@ export class EntityDiagramPart implements DiagramPart {
   }
 
   /**
-   * Set the y coordinate at which the lifeline stops. This is an absolute coordinate,
-   * independent of the lifeline's anchor position.
+   * Set the y coordinate at which the lifeline stops, and the mode of stopping.
+   * The coordinate is absolute, independent of the lifeline's anchor position.
    *
    * @param endHeight The absolute height at which the lifeline stops.
+   * @param destroy Whether the lifeline ends with a destruction, or simply ends.
    */
-  setLifelineEnd (endHeight: number): void {
+  setLifelineEnd (endHeight: number, destroy: boolean): void {
     this.lifelineEndY = endHeight
+    this.destroy = destroy
   }
 
   draw (renderer: Renderer): void {
     this.drawable.setTopCenter(this.topCenter)
-    this.drawable.setEndHeight(this.lifelineEndY)
+    this.drawable.setEnd(this.lifelineEndY, this.destroy)
     this.drawable.draw(renderer)
   }
 }

--- a/src/diagram/parts/message-diagram-part.ts
+++ b/src/diagram/parts/message-diagram-part.ts
@@ -221,7 +221,8 @@ export class MessageDiagramPart implements DiagramPart {
 
     const fromBar = this.message.from != null ? { x: this.fromX, level: this.fromLevel } : undefined
     const toBar = this.message.to != null ? { x: this.toX, level: this.toLevel } : undefined
-    const points = computeArrowPoints(this.offsetY, fromBar, toBar, this.toHeadWidth)
+    const headWidth = this.message.style === MessageStyle.DESTROY ? 0 : this.toHeadWidth
+    const points = computeArrowPoints(this.offsetY, fromBar, toBar, headWidth)
     this.drawable.setPoints(points)
 
     this.drawable.draw(renderer)

--- a/test/diagram/drawables/lifeline-drawable.test.ts
+++ b/test/diagram/drawables/lifeline-drawable.test.ts
@@ -16,7 +16,7 @@ describe('src/diagram/drawables/lifeline-drawable.ts', function () {
       }
       const obj = new LifelineDrawable(head)
       obj.setTopCenter(new Point(25, 75))
-      obj.setEndHeight(175)
+      obj.setEnd(175, false)
       const attr: RenderAttributes = {
         measureText: () => Size.ZERO
       }
@@ -76,7 +76,7 @@ describe('src/diagram/drawables/lifeline-drawable.ts', function () {
       }
       const obj = new LifelineDrawable(head)
       obj.setTopCenter(new Point(50, 100))
-      obj.setEndHeight(185)
+      obj.setEnd(185, false)
       obj.draw(renderer)
     })
   })


### PR DESCRIPTION
This implements adding of the cross mark at the end of lifelines for objects that are destroyed. Messages end at the cross.
Self-call destruction does not work yet.