### PR TITLE
refactor(renderer): Remove renderLine method

### DIFF
--- a/src/diagram/drawables/lifeline-drawable.ts
+++ b/src/diagram/drawables/lifeline-drawable.ts
@@ -1,7 +1,7 @@
 import { Drawable } from './drawable'
 import { HeadDrawable } from './head-drawable'
 import { Point } from '../../util/geometry/point'
-import { RenderAttributes, Renderer } from '../../renderer/renderer'
+import { LineMarker, RenderAttributes, Renderer } from '../../renderer/renderer'
 import { Size } from '../../util/geometry/size'
 import { LINE_WIDTH_LIFELINES } from '../config'
 import { DestructionDrawable } from './destruction-drawable'
@@ -72,7 +72,7 @@ export class LifelineDrawable implements Drawable {
 
     const lineStart = this.position.translate(0, headSize.height)
     const lineEnd = this.position.withY(this.endHeight)
-    renderer.renderLine(lineStart, lineEnd, {
+    renderer.renderPolyline([lineStart, lineEnd], LineMarker.NONE, LineMarker.NONE, {
       lineWidth: LINE_WIDTH_LIFELINES,
       dashed: true
     })

--- a/src/renderer/browser-svg/browser-svg-renderer.ts
+++ b/src/renderer/browser-svg/browser-svg-renderer.ts
@@ -141,19 +141,6 @@ export class BrowserSvgRenderer implements DirectRenderer<SVGSVGElement> {
     this.addToRender(element)
   }
 
-  renderLine (start: Point, end: Point, options?: StrokeOptions): void {
-    const element = createSvgElement('line')
-    applyAttributes(element, {
-      x1: start.x,
-      y1: start.y,
-      x2: end.x,
-      y2: end.y,
-      stroke: this.foregroundColor,
-      ...convertStrokeToAttributes(options)
-    })
-    this.addToRender(element)
-  }
-
   renderPolyline (points: Point[], end1: LineMarker, end2: LineMarker, options?: StrokeOptions): void {
     if (points.length < 2) return
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -49,16 +49,7 @@ export interface Renderer extends RenderAttributes {
   renderBox: (start: Point, size: Size, options?: StrokeOptions) => void
 
   /**
-   * Render a simple line from one point to another.
-   *
-   * @param start The first point.
-   * @param end The second point.
-   * @param options Options for stroking the line. If not provided, sensible defaults will be used.
-   */
-  renderLine: (start: Point, end: Point, options?: StrokeOptions) => void
-
-  /**
-   * Render a polyline, potentially with markers at the end, useful for arrows.
+   * Render a line consisting of a series of points, potentially with markers at the beginning and end.
    *
    * @param points The points of the polyline (first point, [intermediate points, ..., ], last point).
    * @param end1 The marker to place at the first point.

--- a/test/diagram/diagram.test.ts
+++ b/test/diagram/diagram.test.ts
@@ -15,7 +15,6 @@ describe('src/diagram/diagram.ts', function () {
       const diag = Diagram.create(new Sequence([], []))
       const renderer: Renderer = {
         measureText: () => Size.ZERO,
-        renderLine: () => {},
         renderPolyline: () => {},
         renderBox: () => {},
         renderPath: () => {},
@@ -39,7 +38,6 @@ describe('src/diagram/diagram.ts', function () {
       const diag = Diagram.create(new Sequence([], []))
       const renderer: Renderer = {
         measureText: () => Size.ZERO,
-        renderLine: () => {},
         renderPolyline: () => {},
         renderBox: () => {},
         renderPath: () => {},
@@ -55,7 +53,6 @@ describe('src/diagram/diagram.ts', function () {
       let prevX = 0
       const renderer: Renderer = {
         measureText: () => Size.ZERO,
-        renderLine: () => {},
         renderPolyline: () => {},
         renderBox: () => {},
         renderPath: () => {},
@@ -79,13 +76,12 @@ describe('src/diagram/diagram.ts', function () {
         ]),
         new Activation(new LostMessage(foo, '2'), undefined, [])
       ]))
-      let arrowCount = 0
+      let lineCount = 0
       let barCount = 0
       const renderer: Renderer = {
         measureText: () => Size.ZERO,
-        renderLine: () => {},
         renderPolyline: () => {
-          ++arrowCount
+          ++lineCount
         },
         renderBox: () => {
           ++barCount
@@ -95,7 +91,7 @@ describe('src/diagram/diagram.ts', function () {
       }
       diag.layout(renderer)
       diag.draw(renderer)
-      expect(arrowCount).to.equal(3)
+      expect(lineCount).to.equal(3 + 2) // arrows + lifelines
       expect(barCount).to.equal(2)
     })
   })

--- a/test/diagram/drawables/activation-bar-drawable.test.ts
+++ b/test/diagram/drawables/activation-bar-drawable.test.ts
@@ -26,7 +26,6 @@ describe('src/diagram/drawables/activation-bar-drawable.ts', function () {
           expect(size).to.deep.equal(new Size(23, 90))
           done()
         },
-        renderLine: () => expect.fail(),
         renderPolyline: () => expect.fail(),
         renderPath: () => expect.fail(),
         renderText: () => expect.fail(),

--- a/test/diagram/drawables/actor-head-drawable.test.ts
+++ b/test/diagram/drawables/actor-head-drawable.test.ts
@@ -30,7 +30,6 @@ describe('src/diagram/drawables/actor-head-drawable.ts', function () {
       let pathCalled = false
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: () => expect.fail(),
         renderPolyline: () => expect.fail(),
         renderPath: () => {
           expect(pathCalled).to.be.false
@@ -52,7 +51,6 @@ describe('src/diagram/drawables/actor-head-drawable.ts', function () {
 
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: () => expect.fail(),
         renderPolyline: () => expect.fail(),
         renderPath: (data, pos) => {
           expect(pos).to.deep.equal(position)

--- a/test/diagram/drawables/arrow-drawable.test.ts
+++ b/test/diagram/drawables/arrow-drawable.test.ts
@@ -54,7 +54,6 @@ describe('src/diagram/drawables/arrow-drawable.ts', function () {
       ]
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: () => expect.fail(),
         renderPolyline: (points, end1, end2, stroke) => {
           expect(points).to.deep.equal(expectedPoints)
           expect(end1).to.equal(LineMarker.ARROW_FULL)
@@ -74,7 +73,6 @@ describe('src/diagram/drawables/arrow-drawable.ts', function () {
     it('renders text', function (done) {
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: () => expect.fail(),
         renderPolyline: () => {},
         renderPath: () => expect.fail(),
         renderText: (text, position, fontSize) => {
@@ -97,7 +95,6 @@ describe('src/diagram/drawables/arrow-drawable.ts', function () {
     it('renders dashed if configured', function (done) {
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: () => expect.fail(),
         renderPolyline: (points, end1, end2, stroke) => {
           expect(stroke?.dashed).to.be.true
           done()
@@ -117,7 +114,6 @@ describe('src/diagram/drawables/arrow-drawable.ts', function () {
     it('does not render if no points specified', function () {
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: () => expect.fail(),
         renderPolyline: () => expect.fail(),
         renderPath: () => expect.fail(),
         renderText: () => expect.fail(),

--- a/test/diagram/drawables/box-drawable.test.ts
+++ b/test/diagram/drawables/box-drawable.test.ts
@@ -34,7 +34,6 @@ describe('src/diagram/drawables/box-drawable.ts', function () {
     it('calls renderBox and nothing else', function (done) {
       const renderer: Renderer = {
         renderBox: () => done(),
-        renderLine: () => expect.fail(),
         renderPolyline: () => expect.fail(),
         renderPath: () => expect.fail(),
         renderText: () => expect.fail(),
@@ -50,7 +49,6 @@ describe('src/diagram/drawables/box-drawable.ts', function () {
           renderBox: (start) => {
             expect(start).to.deep.equal(position)
           },
-          renderLine: () => expect.fail(),
           renderPolyline: () => expect.fail(),
           renderPath: () => expect.fail(),
           renderText: () => expect.fail(),

--- a/test/diagram/drawables/component-head-drawable.test.ts
+++ b/test/diagram/drawables/component-head-drawable.test.ts
@@ -29,7 +29,6 @@ describe('src/diagram/drawables/component-head-drawable.ts', function () {
           expect(boxCalled).to.be.false
           boxCalled = true
         },
-        renderLine: () => expect.fail(),
         renderPolyline: () => expect.fail(),
         renderPath: () => expect.fail(),
         renderText: (text: string) => {
@@ -57,7 +56,6 @@ describe('src/diagram/drawables/component-head-drawable.ts', function () {
           expect(pos.y).to.equal(position.y)
           expect(size).to.deep.equal(expectedSize)
         },
-        renderLine: () => expect.fail(),
         renderPolyline: () => expect.fail(),
         renderPath: () => expect.fail(),
         renderText: (text: string, pos: Point) => {

--- a/test/diagram/drawables/lifeline-drawable.test.ts
+++ b/test/diagram/drawables/lifeline-drawable.test.ts
@@ -37,11 +37,11 @@ describe('src/diagram/drawables/lifeline-drawable.ts', function () {
       }
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: () => {
+        renderPolyline: (points) => {
           expect(headCalled).to.be.true
+          expect(points).to.have.lengthOf(2)
           done()
         },
-        renderPolyline: () => expect.fail(),
         renderPath: () => expect.fail(),
         renderText: () => expect.fail(),
         measureText: () => Size.ZERO
@@ -65,11 +65,10 @@ describe('src/diagram/drawables/lifeline-drawable.ts', function () {
       }
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: (pos1, pos2) => {
-          expect(pos1).to.deep.equal(new Point(50, 115))
-          expect(pos2).to.deep.equal(new Point(50, 185))
+        renderPolyline: (points) => {
+          expect(points[0]).to.deep.equal(new Point(50, 115))
+          expect(points[1]).to.deep.equal(new Point(50, 185))
         },
-        renderPolyline: () => expect.fail(),
         renderPath: () => expect.fail(),
         renderText: () => expect.fail(),
         measureText: () => Size.ZERO

--- a/test/diagram/drawables/stick-figure-drawable.test.ts
+++ b/test/diagram/drawables/stick-figure-drawable.test.ts
@@ -21,7 +21,6 @@ describe('src/diagram/drawables/stick-figure-drawable.ts', function () {
     it('calls renderPath and nothing else', function (done) {
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: () => expect.fail(),
         renderPolyline: () => expect.fail(),
         renderPath: (data) => {
           expect(data).to.be.a('string').with.length.greaterThan(0)
@@ -39,7 +38,6 @@ describe('src/diagram/drawables/stick-figure-drawable.ts', function () {
       // eslint-disable-next-line prefer-const
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: () => expect.fail(),
         renderPolyline: () => expect.fail(),
         renderPath: (data, pos) => {
           expect(pos).to.deep.equal(position)

--- a/test/diagram/drawables/text-drawable.test.ts
+++ b/test/diagram/drawables/text-drawable.test.ts
@@ -38,7 +38,6 @@ describe('src/diagram/drawables/text-drawable.ts', function () {
     it('calls renderText and nothing else', function (done) {
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: () => expect.fail(),
         renderPolyline: () => expect.fail(),
         renderPath: () => expect.fail(),
         renderText: (text: string, position: Point, fontSize: number) => {
@@ -56,7 +55,6 @@ describe('src/diagram/drawables/text-drawable.ts', function () {
       const check = (align: TextAlignment, expected: Point): void => {
         const renderer: Renderer = {
           renderBox: () => expect.fail(),
-          renderLine: () => expect.fail(),
           renderPolyline: () => expect.fail(),
           renderPath: () => expect.fail(),
           renderText: (text: string, position: Point) => {

--- a/test/diagram/parts/activation-bar-diagram-part.test.ts
+++ b/test/diagram/parts/activation-bar-diagram-part.test.ts
@@ -16,7 +16,6 @@ describe('src/diagram/parts/activation-bar-diagram-part.ts', function () {
           expect(size.height).to.equal(90)
           done()
         },
-        renderLine: () => {},
         renderPolyline: () => {},
         renderPath: () => {},
         renderText: () => {}

--- a/test/diagram/parts/entity-diagram-part.test.ts
+++ b/test/diagram/parts/entity-diagram-part.test.ts
@@ -34,19 +34,19 @@ describe('src/diagram/parts/entity-diagram-part.ts', function () {
       const renderer: Renderer = {
         measureText: () => Size.ZERO,
         renderBox: () => {},
-        renderLine: (start, end) => {
-          expect(start.x).to.equal(150)
-          expect(start.y).to.be.greaterThan(200).and.lessThan(300)
-          expect(end.x).to.equal(150)
-          expect(end.y).to.equal(700)
+        renderPolyline: (points) => {
+          expect(points).to.have.lengthOf(2)
+          expect(points[0].x).to.equal(150)
+          expect(points[0].y).to.be.greaterThan(200).and.lessThan(300)
+          expect(points[1].x).to.equal(150)
+          expect(points[1].y).to.equal(700)
         },
-        renderPolyline: () => {},
         renderPath: () => {},
         renderText: () => {}
       }
       const part = new EntityDiagramPart(new Entity(EntityType.COMPONENT, 'id', 'name'))
       part.setTopCenter(new Point(150, 200))
-      part.setLifelineEnd(700)
+      part.setLifelineEnd(700, false)
       part.draw(renderer)
     })
   })

--- a/test/diagram/parts/message-diagram-part.test.ts
+++ b/test/diagram/parts/message-diagram-part.test.ts
@@ -89,7 +89,6 @@ describe('src/diagram/parts/message-diagram-part.ts', function () {
       const part = new MessageDiagramPart(0, msg, 1, 2, true)
       const renderer: Renderer = {
         renderBox: () => expect.fail(),
-        renderLine: () => expect.fail(),
         renderPolyline: () => expect.fail(),
         renderPath: () => expect.fail(),
         renderText: () => expect.fail(),
@@ -107,7 +106,6 @@ describe('src/diagram/parts/message-diagram-part.ts', function () {
         const part = new MessageDiagramPart(0, msg, 1, 2, false)
         const renderer: Renderer = {
           renderBox: () => expect.fail(),
-          renderLine: () => expect.fail(),
           renderPolyline: (points, end1, end2, options) => {
             expect(points).to.have.lengthOf(2)
             points.forEach(p => expect(p.y).to.equal(100))


### PR DESCRIPTION
The method is removed because its feature set is a strict subset of the
renderPolyline method's.