### PR TITLE
chore!: Drop support for Node.js older than v18.16.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,8 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 20
           - 18
-          - 16
-          - 14
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "rimraf": "5.0.1",
         "ts-node": "10.9.1",
         "typescript": "5.1.6"
+      },
+      "engines": {
+        "node": ">=18.16.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/meyfa/selena/issues"
   },
   "homepage": "https://github.com/meyfa/selena#readme",
+  "engines": {
+    "node": ">=18.16.1"
+  },
   "devDependencies": {
     "@meyfa/eslint-config": "4.0.0",
     "@types/chai": "4.3.5",


### PR DESCRIPTION
Node.js v18.16.1 is the most recent LTS version at this time. v14 is already at end-of-life, and v16 will reach end-of-life on 2023-09-11.